### PR TITLE
Bump commons-io from 2.6 to 2.7 in /04-05

### DIFF
--- a/04-05/pom.xml
+++ b/04-05/pom.xml
@@ -53,7 +53,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.6</version>
+			<version>2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Bumps commons-io from 2.6 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>